### PR TITLE
Copy usage section from gatsby v1 to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ Set Webpack to resolve root, allowing you to import modules from an absolute pro
 
     `yarn add --dev gatsby-plugin-root-import`
 
+### Usage
+
+Add into `gatsby-config.js`.
+
+```javascript
+// gatsby-config.js
+
+module.exports = {
+  plugins: [
+    'gatsby-plugin-root-import'
+  ]
+}
+```
 
 ### Default Settings
 Webpack v4 drops `resolve.root` in favor of `resolve.alias` found [here](https://webpack.js.org/configuration/resolve/#resolve-alias).


### PR DESCRIPTION
When trying to use this plugin with gatsby v2, I wasn't exactly sure if I needed to declare it in my gatsby-config.js plugins. 
I think copying this usage section from gatsby v1 to v2 would just be more consistent for usage.